### PR TITLE
Remove 'string' type hint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "homepage": "https://brianfaust.de"
     }],
     "require": {
-        "php": "^5.6",
+        "php": "^5.6" || "^7.0",
         "illuminate/support": "5.3.* || 5.4.*",
         "graham-campbell/manager": "^2.4",
         "stripe/stripe-php": "^4.1"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "homepage": "https://brianfaust.de"
     }],
     "require": {
-        "php": "^7.1",
+        "php": "^5.6",
         "illuminate/support": "5.3.* || 5.4.*",
         "graham-campbell/manager": "^2.4",
         "stripe/stripe-php": "^4.1"

--- a/src/Facades/Stripe.php
+++ b/src/Facades/Stripe.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel Stripe.
  *
@@ -31,7 +29,7 @@ class Stripe extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor(): string
+    protected static function getFacadeAccessor()
     {
         return 'stripe';
     }

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel Stripe.
  *

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -31,7 +31,7 @@ class Stripe
         $this->setApiKey($apiKey);
     }
 
-    public function __call(string $method, array $arguments)
+    public function __call($method, array $arguments)
     {
         $sdkClass = substr($method, 3);
 

--- a/src/StripeFactory.php
+++ b/src/StripeFactory.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel Stripe.
  *
@@ -33,7 +31,7 @@ class StripeFactory
      *
      * @return \BrianFaust\Stripe\Stripe
      */
-    public function make(array $config): Stripe
+    public function make(array $config)
     {
         $config = $this->getConfig($config);
 
@@ -49,7 +47,7 @@ class StripeFactory
      *
      * @return array
      */
-    protected function getConfig(array $config): array
+    protected function getConfig(array $config)
     {
         $keys = ['key'];
 
@@ -69,7 +67,7 @@ class StripeFactory
      *
      * @return \BrianFaust\Stripe\Stripe
      */
-    protected function getClient(array $auth): Stripe
+    protected function getClient(array $auth)
     {
         return new Stripe($auth['key']);
     }

--- a/src/StripeManager.php
+++ b/src/StripeManager.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel Stripe.
  *
@@ -54,7 +52,7 @@ class StripeManager extends AbstractManager
      *
      * @return mixed
      */
-    protected function createConnection(array $config): Stripe
+    protected function createConnection(array $config)
     {
         return $this->factory->make($config);
     }
@@ -64,7 +62,7 @@ class StripeManager extends AbstractManager
      *
      * @return string
      */
-    protected function getConfigName(): string
+    protected function getConfigName()
     {
         return 'stripe';
     }
@@ -74,7 +72,7 @@ class StripeManager extends AbstractManager
      *
      * @return \BrianFaust\Stripe\StripeFactory
      */
-    public function getFactory(): StripeFactory
+    public function getFactory()
     {
         return $this->factory;
     }

--- a/src/StripeServiceProvider.php
+++ b/src/StripeServiceProvider.php
@@ -28,7 +28,7 @@ class StripeServiceProvider extends ServiceProvider
     /**
      * Boot the service provider.
      */
-    public function boot(): void
+    public function boot()
     {
         $source = realpath(__DIR__.'/../config/stripe.php');
 
@@ -40,7 +40,7 @@ class StripeServiceProvider extends ServiceProvider
     /**
      * Register the service provider.
      */
-    public function register(): void
+    public function register()
     {
         $this->registerFactory();
         $this->registerManager();
@@ -50,7 +50,7 @@ class StripeServiceProvider extends ServiceProvider
     /**
      * Register the factory class.
      */
-    protected function registerFactory(): void
+    protected function registerFactory()
     {
         $this->app->singleton('stripe.factory', function () {
             return new StripeFactory();
@@ -62,7 +62,7 @@ class StripeServiceProvider extends ServiceProvider
     /**
      * Register the manager class.
      */
-    protected function registerManager(): void
+    protected function registerManager()
     {
         $this->app->singleton('stripe', function (Container $app) {
             $config = $app['config'];
@@ -77,7 +77,7 @@ class StripeServiceProvider extends ServiceProvider
     /**
      * Register the bindings.
      */
-    protected function registerBindings(): void
+    protected function registerBindings()
     {
         $this->app->bind('stripe.connection', function (Container $app) {
             $manager = $app['stripe'];
@@ -93,7 +93,7 @@ class StripeServiceProvider extends ServiceProvider
      *
      * @return string[]
      */
-    public function provides(): array
+    public function provides()
     {
         return [
             'stripe',

--- a/src/StripeServiceProvider.php
+++ b/src/StripeServiceProvider.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 /*
  * This file is part of Laravel Stripe.
  *


### PR DESCRIPTION
PHP does not technically support type hinting scalars such as string or int

Fixes #5 

## Changes proposed in this pull request:
Removed type hinting of string in Stripe::__call